### PR TITLE
Set new default website

### DIFF
--- a/example/src/apps/browser.tsx
+++ b/example/src/apps/browser.tsx
@@ -44,7 +44,7 @@ const Browser = () => {
 
     const desktopEventDispatch = useAppManagerDispatch()
 
-    const defaultUrl = 'https://theoldnet.com'
+    const defaultUrl = 'https://web.archive.org/web/19970404064352/http://www.apple.com/'
 
     const refAddressBar = React.useRef<HTMLInputElement>(null)
     const refIframe = React.useRef<HTMLIFrameElement>(null)

--- a/example/src/apps/browser.tsx
+++ b/example/src/apps/browser.tsx
@@ -50,15 +50,21 @@ const Browser = () => {
     const refIframe = React.useRef<HTMLIFrameElement>(null)
     const [history, setHistory] = React.useState<string[]>([defaultUrl])
     const [historyIndex, setHistoryIndex] = React.useState(0)
+    const [iframeSrc, setIframeSrc] = React.useState(sanitizeUrl(defaultUrl))
     const [urlError, setUrlError] = React.useState(false)
     const [isLoading, setIsLoading] = React.useState(true)
     const loadingTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
     const refToolbar = React.useRef<HTMLDivElement>(null)
     const [isCompact, setIsCompact] = React.useState(false)
 
+    // Refs to avoid stale closures in handleIframeLoad
+    const historyRef = React.useRef(history)
+    const historyIndexRef = React.useRef(historyIndex)
+    historyRef.current = history
+    historyIndexRef.current = historyIndex
+
     const canGoBack = historyIndex > 0
     const canGoForward = historyIndex < history.length - 1
-    const iframeSrc = sanitizeUrl(history[historyIndex])
 
     const clearLoadingTimeout = React.useCallback(() => {
         if (loadingTimeoutRef.current) {
@@ -75,6 +81,26 @@ const Browser = () => {
     const handleIframeLoad = React.useCallback(() => {
         clearLoadingTimeout()
         setIsLoading(false)
+
+        // Try to read the iframe's current URL for in-iframe navigation
+        try {
+            const currentUrl = refIframe.current?.contentWindow?.location.href
+            if (currentUrl && currentUrl !== 'about:blank') {
+                const idx = historyIndexRef.current
+                const hist = historyRef.current
+                if (currentUrl !== hist[idx]) {
+                    const newHistory = [...hist.slice(0, idx + 1), currentUrl]
+                    setHistory(newHistory)
+                    setHistoryIndex(idx + 1)
+                    if (refAddressBar.current) {
+                        refAddressBar.current.value = currentUrl
+                    }
+                    recordVisit(currentUrl)
+                }
+            }
+        } catch {
+            // Cross-origin: cannot read iframe URL
+        }
     }, [clearLoadingTimeout])
 
     // Sync address bar and record default URL on mount
@@ -134,6 +160,7 @@ const Browser = () => {
         startLoading()
         setHistory(prev => [...prev.slice(0, historyIndex + 1), url])
         setHistoryIndex(prev => prev + 1)
+        setIframeSrc(sanitizeUrl(url))
         if (refAddressBar.current) {
             refAddressBar.current.value = url
         }
@@ -161,6 +188,7 @@ const Browser = () => {
         startLoading()
         const newIndex = historyIndex - 1
         setHistoryIndex(newIndex)
+        setIframeSrc(sanitizeUrl(history[newIndex]))
         if (refAddressBar.current) {
             refAddressBar.current.value = history[newIndex]
         }
@@ -171,6 +199,7 @@ const Browser = () => {
         startLoading()
         const newIndex = historyIndex + 1
         setHistoryIndex(newIndex)
+        setIframeSrc(sanitizeUrl(history[newIndex]))
         if (refAddressBar.current) {
             refAddressBar.current.value = history[newIndex]
         }

--- a/src/SystemFolder/SystemResources/Window/ClassicyWindow.tsx
+++ b/src/SystemFolder/SystemResources/Window/ClassicyWindow.tsx
@@ -74,16 +74,19 @@ export const ClassicyWindow: FunctionalComponent<ClassicyWindowProps> = ({
     icon = fileIcon;
   }
 
-  const [size, setSize] = useState<[number, number]>(initialSize);
-  const [clickPosition, setClickPosition] = useState<[number, number]>([0, 0]);
-
-  const clickOffset = [10, 10];
-
   const currentApp = useAppManager(
     (state) => state.System.Manager.App.apps[appId],
   );
+  const currentWindow = currentApp?.windows.find((w) => w.id === id);
   const desktopEventDispatch = useAppManagerDispatch();
   const player = useSoundDispatch();
+
+  const [size, setSize] = useState<[number, number]>(
+    currentWindow?.size ?? initialSize,
+  );
+  const [clickPosition, setClickPosition] = useState<[number, number]>([0, 0]);
+
+  const clickOffset = [10, 10];
 
   const { track } = useClassicyAnalytics();
   const analyticsArgs = useMemo(() => {
@@ -125,8 +128,6 @@ export const ClassicyWindow: FunctionalComponent<ClassicyWindowProps> = ({
   ]);
 
   const windowRef = useRef<HTMLDivElement | null>(null);
-
-  const currentWindow = currentApp?.windows.find((w) => w.id === id);
 
   const ws = useMemo(() => {
     const initialWindowState: ClassicyStoreSystemAppWindow = {
@@ -289,7 +290,8 @@ export const ClassicyWindow: FunctionalComponent<ClassicyWindowProps> = ({
     }
     setResize(false);
     setDragging(false);
-    setMoving(false, [ws.position[0], ws.position[1]]);
+    const rect = windowRef.current?.getBoundingClientRect();
+    setMoving(false, [rect?.left ?? ws.position[0], rect?.top ?? ws.position[1]]);
   };
 
   const setDragging = (toDrag: boolean) => {


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Change the default homepage of the example browser app to an archived 1997 Apple website.