### PR TITLE
Alias classicy to ./src in vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
 			"@": path.resolve(__dirname, "./src/"),
 			"@img": path.resolve(__dirname, "./assets/img"),
 			"@snd": path.resolve(__dirname, "./assets/sounds"),
+			classicy: path.resolve(__dirname, "./src/index.ts"),
 		},
 	},
 });


### PR DESCRIPTION
example/ tests that mock the published classicy package via vi.mock still need the specifier to resolve. Pointing it at src/index.ts unblocks usePagerPlayback.test.ts under CI without requiring the package to be built first.

https://claude.ai/code/session_01Ls4uDcc7ZrB4JybcjSJQrq

## Summary by Sourcery

Tests:
- Add a Vitest alias mapping `classicy` to `./src/index.ts` so tests can mock the package without building it first.