### PR TITLE
fix(TextEditor): reflect prefillValue/content changes after mount

### DIFF
--- a/src/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor.test.tsx
+++ b/src/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@/__tests__/test-utils";
+import { ClassicyTextEditor } from "@/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor";
+
+vi.mock(
+	"@/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor.scss",
+	() => ({}),
+);
+vi.mock(
+	"@/SystemFolder/SystemResources/ControlLabel/ClassicyControlLabel.scss",
+	() => ({}),
+);
+
+describe("ClassicyTextEditor", () => {
+	it("shows the initial prefillValue", () => {
+		const { container } = render(
+			<ClassicyTextEditor id="t" prefillValue="hello" disabled />,
+		);
+		expect(container.querySelector("textarea")?.value).toBe("hello");
+	});
+
+	it("reflects a prefillValue that changes after mount", () => {
+		// Reproduces the bug: content fetched asynchronously and supplied via a later
+		// prefillValue must appear, not be ignored because the field is uncontrolled.
+		const { container, rerender } = render(
+			<ClassicyTextEditor id="t" prefillValue="Loading…" disabled />,
+		);
+		expect(container.querySelector("textarea")?.value).toBe("Loading…");
+
+		rerender(<ClassicyTextEditor id="t" prefillValue="the real body" disabled />);
+		expect(container.querySelector("textarea")?.value).toBe("the real body");
+	});
+
+	it("falls back to content when prefillValue is absent", () => {
+		const { container } = render(
+			<ClassicyTextEditor id="t" content="from content" disabled />,
+		);
+		expect(container.querySelector("textarea")?.value).toBe("from content");
+	});
+});

--- a/src/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor.tsx
+++ b/src/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor.tsx
@@ -1,6 +1,6 @@
 import "./ClassicyTextEditor.scss";
 import classNames from "classnames";
-import type { FC as FunctionalComponent } from "react";
+import { type FC as FunctionalComponent, useEffect, useState } from "react";
 import {
 	ClassicyControlLabel,
 	type ClassicyControlLabelSize,
@@ -41,6 +41,15 @@ export const ClassicyTextEditor: FunctionalComponent<EditorProps> = ({
 	labelSize = "medium",
 	labelPosition = "above",
 }) => {
+	// Controlled with internal state so the editor reflects later prefillValue/
+	// content changes. A bare <textarea defaultValue> is uncontrolled and snapshots
+	// its text once at mount, ignoring prop updates — which breaks any consumer that
+	// fills the value asynchronously (e.g. text fetched after the editor renders).
+	const [value, setValue] = useState(prefillValue ?? content ?? "");
+	useEffect(() => {
+		setValue(prefillValue ?? content ?? "");
+	}, [prefillValue, content]);
+
 	return (
 		<div
 			className={classNames(
@@ -65,7 +74,8 @@ export const ClassicyTextEditor: FunctionalComponent<EditorProps> = ({
 					autoHeight && "classicyTextEditorAutoHeight",
 					border && "classicyTextEditorBorder",
 				)}
-				defaultValue={prefillValue ?? content}
+				value={value}
+				onChange={(e) => setValue(e.target.value)}
 			/>
 		</div>
 	);


### PR DESCRIPTION
## Problem

`ClassicyTextEditor` renders an **uncontrolled** textarea:

```tsx
<textarea ... defaultValue={prefillValue ?? content} />
```

`defaultValue` is read once at mount and ignored on subsequent prop changes. Any consumer that supplies the text **asynchronously** — e.g. a message body fetched on demand after the editor has already rendered — stays stuck showing the initial placeholder. The text only appears if the editor is unmounted and remounted.

We hit this in a consuming app: a newsgroup message window opened with `prefillValue="Loading message…"`, the body arrived a moment later via a prop update, and the textarea never reflected it (closing and reopening the window worked, because that remounts the field).

## Fix

Make the editor controlled with internal state, synced to `prefillValue`/`content`:

```tsx
const [value, setValue] = useState(prefillValue ?? content ?? "");
useEffect(() => {
  setValue(prefillValue ?? content ?? "");
}, [prefillValue, content]);
...
<textarea ... value={value} onChange={(e) => setValue(e.target.value)} />
```

Prop updates are now reflected, and typing still works (local state). No public API change.

## Tests

Adds `ClassicyTextEditor.test.tsx`:
- shows the initial `prefillValue`
- **reflects a `prefillValue` that changes after mount** (the regression; fails on `main`, passes here)
- falls back to `content` when `prefillValue` is absent

Verified the change-after-mount test fails before the fix and passes after. Full suite: no new failures introduced (pre-existing localStorage/jsdom failures in `ClassicyFileSystem`/`ClassicyAppManagerUtils` are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make the text editor textarea controlled so it updates when prefill/content props change after mount and add tests for the new behavior.

Bug Fixes:
- Ensure ClassicyTextEditor updates its displayed value when prefillValue or content props change after initial mount.

Tests:
- Add ClassicyTextEditor tests covering initial prefillValue, post-mount prefillValue updates, and fallback to content when no prefillValue is provided.