### PR TITLE
feat: ClassicyButton rest-prop spread, ClassicyTextEditor onChangeFunc, ClassicyFileInput component

### DIFF
--- a/src/SystemFolder/SystemResources/Button/ClassicyButton.test.tsx
+++ b/src/SystemFolder/SystemResources/Button/ClassicyButton.test.tsx
@@ -111,4 +111,9 @@ describe("ClassicyButton", () => {
 		expect(btn.className).not.toMatch(/classicyButtonPadding/);
 		expect(btn).toHaveClass("classicyButtonMarginLg");
 	});
+
+	it("forwards aria-label to the underlying button element", () => {
+		render(<ClassicyButton aria-label="Remove file.png">✕</ClassicyButton>);
+		expect(screen.getByRole("button", { name: "Remove file.png" })).toBeInTheDocument();
+	});
 });

--- a/src/SystemFolder/SystemResources/Button/ClassicyButton.tsx
+++ b/src/SystemFolder/SystemResources/Button/ClassicyButton.tsx
@@ -23,7 +23,7 @@ type ClassicyButtonProps = PropsWithChildren<{
 	padding?: "sm" | "md" | "lg" | "xl";
 	/** Outer spacing variant; scales off --window-padding-size. */
 	margin?: "sm" | "md" | "lg" | "xl";
-}> & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onClick" | "type" | "disabled">;
+}> & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onClick" | "type" | "disabled" | "onMouseDown" | "onMouseUp">;
 
 const paddingVariantClass = {
 	sm: "classicyButtonPaddingSm",

--- a/src/SystemFolder/SystemResources/Button/ClassicyButton.tsx
+++ b/src/SystemFolder/SystemResources/Button/ClassicyButton.tsx
@@ -1,6 +1,7 @@
 import "./ClassicyButton.scss";
 import classNames from "classnames";
 import type {
+	ButtonHTMLAttributes,
 	FC as FunctionalComponent,
 	MouseEvent,
 	MouseEventHandler,
@@ -22,7 +23,7 @@ type ClassicyButtonProps = PropsWithChildren<{
 	padding?: "sm" | "md" | "lg" | "xl";
 	/** Outer spacing variant; scales off --window-padding-size. */
 	margin?: "sm" | "md" | "lg" | "xl";
-}>;
+}> & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onClick" | "type" | "disabled">;
 
 const paddingVariantClass = {
 	sm: "classicyButtonPaddingSm",
@@ -49,6 +50,7 @@ export const ClassicyButton: FunctionalComponent<ClassicyButtonProps> = ({
 	margin = "md",
 	onClickFunc,
 	children,
+	...rest
 }) => {
 	const player = useSoundDispatch();
 
@@ -64,6 +66,7 @@ export const ClassicyButton: FunctionalComponent<ClassicyButtonProps> = ({
 
 	return (
 		<button
+			{...rest}
 			type={buttonType}
 			tabIndex={0}
 			role={buttonType}

--- a/src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.scss
+++ b/src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.scss
@@ -19,7 +19,6 @@
   width: 1px;
   height: 1px;
   opacity: 0;
-  pointer-events: none;
   overflow: hidden;
   clip: rect(0 0 0 0);
   clip-path: inset(50%);

--- a/src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.scss
+++ b/src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.scss
@@ -1,0 +1,50 @@
+/* src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.scss */
+@use '../../ControlPanels/AppearanceManager/styles/appearance';
+
+.classicyFileInputHolder {
+  display: flex;
+  width: 100%;
+}
+
+.classicyFileInputBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--window-padding-size);
+  width: 100%;
+}
+
+/* Visually hidden but stays in accessibility tree for label association */
+.classicyFileInputNative {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.classicyFileInputError {
+  font-family: var(--ui-font), sans-serif;
+  font-size: var(--ui-font-size);
+  color: #c00;
+}
+
+.classicyFileInputList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--window-padding-size) / 2);
+}
+
+.classicyFileInputItem {
+  display: flex;
+  align-items: center;
+  gap: var(--window-padding-size);
+  font-family: var(--ui-font), sans-serif;
+  font-size: var(--ui-font-size);
+}

--- a/src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.test.tsx
+++ b/src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.test.tsx
@@ -1,0 +1,123 @@
+// src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.test.tsx
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/__tests__/test-utils";
+import { createRef } from "react";
+import { ClassicyFileInput, type ClassicyFileInputHandle } from "@/SystemFolder/SystemResources/FileInput/ClassicyFileInput";
+
+vi.mock("@/SystemFolder/SystemResources/FileInput/ClassicyFileInput.scss", () => ({}));
+vi.mock("@/SystemFolder/SystemResources/ControlLabel/ClassicyControlLabel.scss", () => ({}));
+vi.mock("@/SystemFolder/SystemResources/Button/ClassicyButton.scss", () => ({}));
+vi.mock("@/SystemFolder/SystemResources/Analytics/useClassicyAnalytics", () => ({
+    useClassicyAnalytics: () => ({ track: vi.fn() }),
+}));
+vi.mock("@/SystemFolder/ControlPanels/SoundManager/ClassicySoundManagerContext", () => ({
+    useSoundDispatch: () => vi.fn(),
+}));
+
+function addFiles(files: File[]) {
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    Object.defineProperty(input, "files", { value: files, configurable: true });
+    fireEvent.change(input);
+}
+
+describe("ClassicyFileInput", () => {
+    it("renders a hidden file input", () => {
+        render(<ClassicyFileInput id="fi-test" />);
+        expect(document.querySelector('input[type="file"]')).toBeInTheDocument();
+    });
+
+    it("renders a label when labelTitle is provided", () => {
+        render(<ClassicyFileInput id="fi-test" labelTitle="Attachments" />);
+        expect(screen.getByText("Attachments")).toBeInTheDocument();
+    });
+
+    it("renders a Choose Files button", () => {
+        render(<ClassicyFileInput id="fi-test" multiple />);
+        expect(screen.getByRole("button", { name: /choose files/i })).toBeInTheDocument();
+    });
+
+    it("renders a Choose File button when multiple is false", () => {
+        render(<ClassicyFileInput id="fi-test" />);
+        expect(screen.getByRole("button", { name: /choose file/i })).toBeInTheDocument();
+    });
+
+    it("shows filename after a file is selected", async () => {
+        render(<ClassicyFileInput id="fi-test" multiple />);
+        addFiles([new File(["x"], "photo.png", { type: "image/png" })]);
+        await waitFor(() => expect(screen.getByText("photo.png")).toBeInTheDocument());
+    });
+
+    it("calls onChangeFunc with the added file list", async () => {
+        const onChange = vi.fn();
+        render(<ClassicyFileInput id="fi-test" multiple onChangeFunc={onChange} />);
+        const file = new File(["x"], "doc.pdf", { type: "application/pdf" });
+        addFiles([file]);
+        await waitFor(() => expect(onChange).toHaveBeenCalledWith([file]));
+    });
+
+    it("removes a file when its remove button is clicked", async () => {
+        render(<ClassicyFileInput id="fi-test" multiple />);
+        addFiles([new File(["x"], "photo.png", { type: "image/png" })]);
+        await waitFor(() => screen.getByText("photo.png"));
+        fireEvent.click(screen.getByRole("button", { name: /remove photo\.png/i }));
+        expect(screen.queryByText("photo.png")).not.toBeInTheDocument();
+    });
+
+    it("calls onChangeFunc with updated list after remove", async () => {
+        const onChange = vi.fn();
+        render(<ClassicyFileInput id="fi-test" multiple onChangeFunc={onChange} />);
+        const file = new File(["x"], "a.png", { type: "image/png" });
+        addFiles([file]);
+        await waitFor(() => screen.getByText("a.png"));
+        fireEvent.click(screen.getByRole("button", { name: /remove a\.png/i }));
+        expect(onChange).toHaveBeenLastCalledWith([]);
+    });
+
+    it("shows error when maxFiles is exceeded", async () => {
+        render(<ClassicyFileInput id="fi-test" multiple maxFiles={2} />);
+        addFiles([
+            new File(["x"], "a.png", { type: "image/png" }),
+            new File(["x"], "b.png", { type: "image/png" }),
+            new File(["x"], "c.png", { type: "image/png" }),
+        ]);
+        await waitFor(() => expect(screen.getByText(/max 2 files/i)).toBeInTheDocument());
+    });
+
+    it("shows error when a file exceeds maxFileSizeMb", async () => {
+        render(<ClassicyFileInput id="fi-test" multiple maxFileSizeMb={1} />);
+        addFiles([new File([new Uint8Array(2 * 1024 * 1024)], "big.png", { type: "image/png" })]);
+        await waitFor(() => expect(screen.getByText(/exceeds 1 mb/i)).toBeInTheDocument());
+    });
+
+    it("does not add files when validation fails", async () => {
+        render(<ClassicyFileInput id="fi-test" multiple maxFiles={1} />);
+        addFiles([
+            new File(["x"], "a.png", { type: "image/png" }),
+            new File(["x"], "b.png", { type: "image/png" }),
+        ]);
+        await waitFor(() => screen.getByText(/max 1 files/i));
+        expect(screen.queryByText("a.png")).not.toBeInTheDocument();
+    });
+
+    it("addFiles ref method adds files to the list", async () => {
+        const ref = createRef<ClassicyFileInputHandle>();
+        render(<ClassicyFileInput ref={ref} id="fi-test" multiple />);
+        const file = new File(["x"], "screen.png", { type: "image/png" });
+        ref.current?.addFiles([file]);
+        await waitFor(() => expect(screen.getByText("screen.png")).toBeInTheDocument());
+    });
+
+    it("addFiles calls onChangeFunc", async () => {
+        const onChange = vi.fn();
+        const ref = createRef<ClassicyFileInputHandle>();
+        render(<ClassicyFileInput ref={ref} id="fi-test" multiple onChangeFunc={onChange} />);
+        const file = new File(["x"], "screen.png", { type: "image/png" });
+        ref.current?.addFiles([file]);
+        await waitFor(() => expect(onChange).toHaveBeenCalledWith([file]));
+    });
+
+    it("disabled prop disables the native input", () => {
+        render(<ClassicyFileInput id="fi-test" disabled />);
+        expect(document.querySelector('input[type="file"]')).toBeDisabled();
+    });
+});

--- a/src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.tsx
+++ b/src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.tsx
@@ -3,7 +3,6 @@ import "./ClassicyFileInput.scss";
 import classNames from "classnames";
 import {
     type ChangeEvent,
-    type FC as FunctionalComponent,
     forwardRef,
     useCallback,
     useImperativeHandle,
@@ -36,7 +35,7 @@ interface ClassicyFileInputProps {
     onChangeFunc?: (files: File[]) => void;
 }
 
-export const ClassicyFileInput: FunctionalComponent<ClassicyFileInputProps> = forwardRef<
+export const ClassicyFileInput = forwardRef<
     ClassicyFileInputHandle,
     ClassicyFileInputProps
 >(function ClassicyFileInput(
@@ -55,14 +54,16 @@ export const ClassicyFileInput: FunctionalComponent<ClassicyFileInputProps> = fo
     },
     ref,
 ) {
-    const [files, setFiles] = useState<File[]>([]);
+    type FileEntry = { id: string; file: File };
+    const entryCounter = useRef(0);
+    const [entries, setEntries] = useState<FileEntry[]>([]);
     const [error, setError] = useState<string | null>(null);
     const inputRef = useRef<HTMLInputElement>(null);
 
     const tryAdd = useCallback(
-        (currentFiles: File[], incoming: File[]): File[] | null => {
-            const combined = [...currentFiles, ...incoming];
-            if (maxFiles !== undefined && combined.length > maxFiles) {
+        (currentEntries: FileEntry[], incoming: File[]): FileEntry[] | null => {
+            const combined = currentEntries.length + incoming.length;
+            if (maxFiles !== undefined && combined > maxFiles) {
                 setError(`Max ${maxFiles} files allowed.`);
                 return null;
             }
@@ -75,7 +76,11 @@ export const ClassicyFileInput: FunctionalComponent<ClassicyFileInputProps> = fo
                     return null;
                 }
             }
-            return combined;
+            const newEntries = incoming.map((f) => ({
+                id: `${f.name}:${f.size}:${f.lastModified}:${++entryCounter.current}`,
+                file: f,
+            }));
+            return [...currentEntries, ...newEntries];
         },
         [maxFiles, maxFileSizeMb],
     );
@@ -83,12 +88,12 @@ export const ClassicyFileInput: FunctionalComponent<ClassicyFileInputProps> = fo
     const addFiles = useCallback(
         (incoming: File[]) => {
             setError(null);
-            const next = tryAdd(files, incoming);
+            const next = tryAdd(entries, incoming);
             if (next === null) return;
-            setFiles(next);
-            onChangeFunc?.(next);
+            setEntries(next);
+            onChangeFunc?.(next.map((e) => e.file));
         },
-        [files, tryAdd, onChangeFunc],
+        [entries, tryAdd, onChangeFunc],
     );
 
     useImperativeHandle(ref, () => ({ addFiles }), [addFiles]);
@@ -103,12 +108,13 @@ export const ClassicyFileInput: FunctionalComponent<ClassicyFileInputProps> = fo
     );
 
     const handleRemove = useCallback(
-        (name: string) => {
-            const updated = files.filter((f) => f.name !== name);
-            setFiles(updated);
-            onChangeFunc?.(updated);
+        (id: string) => {
+            setError(null);
+            const updated = entries.filter((e) => e.id !== id);
+            setEntries(updated);
+            onChangeFunc?.(updated.map((e) => e.file));
         },
-        [files, onChangeFunc],
+        [entries, onChangeFunc],
     );
 
     return (
@@ -144,18 +150,18 @@ export const ClassicyFileInput: FunctionalComponent<ClassicyFileInputProps> = fo
                     {multiple ? "Choose Files…" : "Choose File…"}
                 </ClassicyButton>
                 {error && (
-                    <span className="classicyFileInputError">{error}</span>
+                    <span role="alert" className="classicyFileInputError">{error}</span>
                 )}
-                {files.length > 0 && (
+                {entries.length > 0 && (
                     <ul className="classicyFileInputList">
-                        {files.map((f) => (
-                            <li key={f.name} className="classicyFileInputItem">
-                                <span>{f.name}</span>
+                        {entries.map((entry) => (
+                            <li key={entry.id} className="classicyFileInputItem">
+                                <span>{entry.file.name}</span>
                                 <ClassicyButton
                                     buttonSize="small"
                                     disabled={disabled}
-                                    onClickFunc={() => handleRemove(f.name)}
-                                    aria-label={`Remove ${f.name}`}
+                                    onClickFunc={() => handleRemove(entry.id)}
+                                    aria-label={`Remove ${entry.file.name}`}
                                 >
                                     ✕
                                 </ClassicyButton>

--- a/src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.tsx
+++ b/src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.tsx
@@ -1,0 +1,169 @@
+// src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.tsx
+import "./ClassicyFileInput.scss";
+import classNames from "classnames";
+import {
+    type ChangeEvent,
+    type FC as FunctionalComponent,
+    forwardRef,
+    useCallback,
+    useImperativeHandle,
+    useRef,
+    useState,
+} from "react";
+import { ClassicyButton } from "@/SystemFolder/SystemResources/Button/ClassicyButton";
+import {
+    ClassicyControlLabel,
+    type ClassicyControlLabelSize,
+    type ClassicyLabelPosition,
+    labelPositionClass,
+} from "@/SystemFolder/SystemResources/ControlLabel/ClassicyControlLabel";
+
+export interface ClassicyFileInputHandle {
+    addFiles: (incoming: File[]) => void;
+}
+
+interface ClassicyFileInputProps {
+    id: string;
+    accept?: string;
+    multiple?: boolean;
+    maxFiles?: number;
+    maxFileSizeMb?: number;
+    disabled?: boolean;
+    labelTitle?: string;
+    labelPosition?: ClassicyLabelPosition;
+    labelSize?: ClassicyControlLabelSize;
+    labelDisabled?: boolean;
+    onChangeFunc?: (files: File[]) => void;
+}
+
+export const ClassicyFileInput: FunctionalComponent<ClassicyFileInputProps> = forwardRef<
+    ClassicyFileInputHandle,
+    ClassicyFileInputProps
+>(function ClassicyFileInput(
+    {
+        id,
+        accept,
+        multiple = false,
+        maxFiles,
+        maxFileSizeMb,
+        disabled = false,
+        labelTitle,
+        labelPosition = "above",
+        labelSize = "medium",
+        labelDisabled,
+        onChangeFunc,
+    },
+    ref,
+) {
+    const [files, setFiles] = useState<File[]>([]);
+    const [error, setError] = useState<string | null>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const tryAdd = useCallback(
+        (currentFiles: File[], incoming: File[]): File[] | null => {
+            const combined = [...currentFiles, ...incoming];
+            if (maxFiles !== undefined && combined.length > maxFiles) {
+                setError(`Max ${maxFiles} files allowed.`);
+                return null;
+            }
+            if (maxFileSizeMb !== undefined) {
+                const oversized = incoming.find(
+                    (f) => f.size > maxFileSizeMb * 1024 * 1024,
+                );
+                if (oversized) {
+                    setError(`"${oversized.name}" exceeds ${maxFileSizeMb} MB.`);
+                    return null;
+                }
+            }
+            return combined;
+        },
+        [maxFiles, maxFileSizeMb],
+    );
+
+    const addFiles = useCallback(
+        (incoming: File[]) => {
+            setError(null);
+            const next = tryAdd(files, incoming);
+            if (next === null) return;
+            setFiles(next);
+            onChangeFunc?.(next);
+        },
+        [files, tryAdd, onChangeFunc],
+    );
+
+    useImperativeHandle(ref, () => ({ addFiles }), [addFiles]);
+
+    const handleChange = useCallback(
+        (e: ChangeEvent<HTMLInputElement>) => {
+            const incoming = Array.from(e.target.files ?? []);
+            if (incoming.length > 0) addFiles(incoming);
+            if (inputRef.current) inputRef.current.value = "";
+        },
+        [addFiles],
+    );
+
+    const handleRemove = useCallback(
+        (name: string) => {
+            const updated = files.filter((f) => f.name !== name);
+            setFiles(updated);
+            onChangeFunc?.(updated);
+        },
+        [files, onChangeFunc],
+    );
+
+    return (
+        <div
+            className={classNames(
+                "classicyFileInputHolder",
+                labelPositionClass(labelPosition),
+            )}
+        >
+            {labelTitle && (
+                <ClassicyControlLabel
+                    label={labelTitle}
+                    labelFor={id}
+                    labelSize={labelSize}
+                    disabled={labelDisabled ?? disabled}
+                />
+            )}
+            <div className="classicyFileInputBody">
+                <input
+                    id={id}
+                    ref={inputRef}
+                    type="file"
+                    accept={accept}
+                    multiple={multiple}
+                    disabled={disabled}
+                    className="classicyFileInputNative"
+                    onChange={handleChange}
+                />
+                <ClassicyButton
+                    disabled={disabled}
+                    onClickFunc={() => inputRef.current?.click()}
+                >
+                    {multiple ? "Choose Files…" : "Choose File…"}
+                </ClassicyButton>
+                {error && (
+                    <span className="classicyFileInputError">{error}</span>
+                )}
+                {files.length > 0 && (
+                    <ul className="classicyFileInputList">
+                        {files.map((f) => (
+                            <li key={f.name} className="classicyFileInputItem">
+                                <span>{f.name}</span>
+                                <ClassicyButton
+                                    buttonSize="small"
+                                    disabled={disabled}
+                                    onClickFunc={() => handleRemove(f.name)}
+                                    aria-label={`Remove ${f.name}`}
+                                >
+                                    ✕
+                                </ClassicyButton>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        </div>
+    );
+});

--- a/src/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor.test.tsx
+++ b/src/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render } from "@/__tests__/test-utils";
+import { fireEvent, render, screen } from "@/__tests__/test-utils";
 import { ClassicyTextEditor } from "@/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor";
 
 vi.mock(
@@ -36,5 +36,25 @@ describe("ClassicyTextEditor", () => {
 			<ClassicyTextEditor id="t" content="from content" disabled />,
 		);
 		expect(container.querySelector("textarea")?.value).toBe("from content");
+	});
+
+	it("calls onChangeFunc when the textarea content changes", () => {
+		const onChange = vi.fn();
+		render(<ClassicyTextEditor id="te-1" onChangeFunc={onChange} />);
+		fireEvent.change(screen.getByRole("textbox"), { target: { value: "new text" } });
+		expect(onChange).toHaveBeenCalledOnce();
+		expect(onChange.mock.calls[0][0].target.value).toBe("new text");
+	});
+
+	it("does not throw when onChangeFunc is omitted", () => {
+		render(<ClassicyTextEditor id="te-1" />);
+		expect(() =>
+			fireEvent.change(screen.getByRole("textbox"), { target: { value: "x" } })
+		).not.toThrow();
+	});
+
+	it("respects disabled prop", () => {
+		render(<ClassicyTextEditor id="te-1" disabled />);
+		expect(screen.getByRole("textbox")).toBeDisabled();
 	});
 });

--- a/src/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor.tsx
+++ b/src/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor.tsx
@@ -1,6 +1,6 @@
 import "./ClassicyTextEditor.scss";
 import classNames from "classnames";
-import { type ChangeEventHandler, type FC as FunctionalComponent, useEffect, useState } from "react";
+import { type ChangeEvent, type ChangeEventHandler, type FC as FunctionalComponent, useCallback, useEffect, useState } from "react";
 import {
 	ClassicyControlLabel,
 	type ClassicyControlLabelSize,
@@ -52,6 +52,14 @@ export const ClassicyTextEditor: FunctionalComponent<EditorProps> = ({
 		setValue(prefillValue ?? content ?? "");
 	}, [prefillValue, content]);
 
+	const handleChange = useCallback(
+		(e: ChangeEvent<HTMLTextAreaElement>) => {
+			setValue(e.target.value);
+			onChangeFunc?.(e);
+		},
+		[onChangeFunc],
+	);
+
 	return (
 		<div
 			className={classNames(
@@ -77,10 +85,7 @@ export const ClassicyTextEditor: FunctionalComponent<EditorProps> = ({
 					border && "classicyTextEditorBorder",
 				)}
 				value={value}
-				onChange={(e) => {
-					setValue(e.target.value);
-					onChangeFunc?.(e);
-				}}
+				onChange={handleChange}
 			/>
 		</div>
 	);

--- a/src/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor.tsx
+++ b/src/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor.tsx
@@ -1,6 +1,6 @@
 import "./ClassicyTextEditor.scss";
 import classNames from "classnames";
-import { type FC as FunctionalComponent, useEffect, useState } from "react";
+import { type ChangeEventHandler, type FC as FunctionalComponent, useEffect, useState } from "react";
 import {
 	ClassicyControlLabel,
 	type ClassicyControlLabelSize,
@@ -20,6 +20,7 @@ export interface EditorProps {
 	labelTitle?: string;
 	labelSize?: ClassicyControlLabelSize;
 	labelPosition?: ClassicyLabelPosition;
+	onChangeFunc?: ChangeEventHandler<HTMLTextAreaElement>;
 }
 
 const fontSizeClass: Record<ClassicyControlLabelSize, string> = {
@@ -40,6 +41,7 @@ export const ClassicyTextEditor: FunctionalComponent<EditorProps> = ({
 	labelTitle,
 	labelSize = "medium",
 	labelPosition = "above",
+	onChangeFunc,
 }) => {
 	// Controlled with internal state so the editor reflects later prefillValue/
 	// content changes. A bare <textarea defaultValue> is uncontrolled and snapshots
@@ -75,7 +77,10 @@ export const ClassicyTextEditor: FunctionalComponent<EditorProps> = ({
 					border && "classicyTextEditorBorder",
 				)}
 				value={value}
-				onChange={(e) => setValue(e.target.value)}
+				onChange={(e) => {
+					setValue(e.target.value);
+					onChangeFunc?.(e);
+				}}
 			/>
 		</div>
 	);

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export * from "./SystemFolder/SystemResources/File/ClassicyFileSystem";
 export * from "./SystemFolder/SystemResources/File/ClassicyFileSystemModel";
 export * from "./SystemFolder/SystemResources/File/ClassicyFileSystemValidation";
 export * from "./SystemFolder/SystemResources/File/DefaultClassicyFileSystem";
+export * from "./SystemFolder/SystemResources/FileInput/ClassicyFileInput";
 export * from "./SystemFolder/SystemResources/Icon/ClassicyIcon";
 export * from "./SystemFolder/SystemResources/Input/ClassicyInput";
 export * from "./SystemFolder/SystemResources/Menu/ClassicyMenu";


### PR DESCRIPTION
## Summary

- **ClassicyButton**: Forward HTML rest props (`aria-label`, etc.) to the underlying `<button>` element via spread, excluding `onClick`, `type`, `disabled`, `onMouseDown`, `onMouseUp` which are managed internally
- **ClassicyTextEditor**: Add `onChangeFunc` prop (`ChangeEventHandler<HTMLTextAreaElement>`) for controlled change tracking; component remains internally controlled via `useState`+`useEffect` to support async `prefillValue` updates
- **ClassicyFileInput**: New batteries-included file picker — owns `File[]` state internally, exposes `addFiles(File[])` via `forwardRef`/`useImperativeHandle`, calls `onChangeFunc(files)` on add/remove, validates `maxFiles`/`maxFileSizeMb` with inline errors, visually-hides native input for accessibility, remove buttons carry `aria-label="Remove <filename>"`

## Test Plan

- [ ] `pnpm exec vitest run src/SystemFolder/SystemResources/Button/ClassicyButton.test.tsx` — 12 tests pass (includes `aria-label` forwarding)
- [ ] `pnpm exec vitest run src/SystemFolder/SystemResources/TextEditor/ClassicyTextEditor.test.tsx` — 6 tests pass (includes `onChangeFunc` and disabled)
- [ ] `pnpm exec vitest run src/SystemFolder/SystemResources/FileInput/ClassicyFileInput.test.tsx` — 14 tests pass (add, remove, validation, ref handle, disabled)
- [ ] `pnpm exec vitest run` — 660 tests pass across 45 files

## Summary by Sourcery

Add a new ClassicyFileInput component, extend ClassicyTextEditor with change callbacks, and enhance ClassicyButton to forward standard HTML button attributes for accessibility.

New Features:
- Introduce ClassicyFileInput as a stateful file picker component with validation, labels, and removable file list.
- Expose an onChangeFunc callback prop on ClassicyTextEditor to notify callers when textarea content changes.

Enhancements:
- Allow ClassicyButton to accept and forward standard HTML button attributes such as aria-label to the underlying element.
- Export ClassicyFileInput from the package index for external consumption.

Tests:
- Add unit tests covering ClassicyTextEditor onChangeFunc behavior and disabled state handling.
- Add unit tests verifying ClassicyButton forwards aria-label to the underlying button.
- Add unit tests for ClassicyFileInput covering rendering, file add/remove flows, validation rules, ref addFiles method, and disabled state.